### PR TITLE
bug fix: allow storageAccountKeyEnvVar as a config key

### DIFF
--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -237,6 +237,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		storageAccountConfigKey,
 		subscriptionIdConfigKey,
 		blockSizeConfigKey,
+		storageAccountKeyEnvVarConfigKey,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Steve Kriss <krisss@vmware.com>

cc @tabishis

The `storageAccountKeyEnvVar` config key was added in #32, but the validation wasn't updated to allow it as a valid key. This PR fixes that.