### PR TITLE
Add documentation around minimum required permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,41 @@ If you plan to use Velero to take Azure snapshots of your persistent volume mana
 
 If you don't plan to take Azure disk snapshots, any method is valid.
 
+### Minimum Required permissions
+
+It is always best practice to assign the minimum required permissions necessary for an application to do its work. 
+The following are the minimum required permissions needed by Velero to perform backups, restores, and deletions.
+
+#### Storage Account
+
+There are two *Azure Roles* that provide the necessary permissions for the [service principal][17] or the [AAD Pod Identity][20]:
+
+* [Storage Blob Data Contributor](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor)
+* [Storage Account Key Operator Service Role](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-account-key-operator-service-role)
+
+#### Snapshot and Disk Management
+
+There aren't any predefined Roles in Azure that define the minimum required permissions for Velero to manage disks and snapshots.
+[Custom Roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles) can be defined using the following Azure API permissions.
+
+#### Velero Disk Management
+
+These permissions are required on the Resource Group where the disks are be located, which may be different from where the snapshots are located.
+
+* Microsoft.Compute/disks/read
+* Microsoft.Compute/disks/write
+* Microsoft.Compute/disks/endGetAccess/action
+* Microsoft.Compute/disks/beginGetAccess/action
+
+#### Velero Snapshot Management
+
+These permissions are required on the Resource Group where the snapshots will be located, which may be different from where the disks are located.
+
+* Microsoft.Compute/snapshots/read
+* Microsoft.Compute/snapshots/write
+* Microsoft.Compute/snapshots/delete
+* Microsoft.Compute/disks/beginGetAccess/action
+* Microsoft.Compute/disks/endGetAccess/action
 
 ### Option 1: Create service principal
 

--- a/README.md
+++ b/README.md
@@ -148,9 +148,7 @@ The following are the minimum required permissions needed by Velero to perform b
 
 #### Storage Account
 
-There are two *Azure Roles* that provide the necessary permissions for the [service principal][17] or the [AAD Pod Identity][20]:
-
-* [Storage Account Key Operator Service Role](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-account-key-operator-service-role)
+To backup to the Storage Account, Velero uses the Storage Account Key which it retrieves via the Azure API if not provided. The [Storage Account Key Operator Service Role](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-account-key-operator-service-role) can be assigned to the [service principal][17] or the [AAD Pod Identity][20] to allow this.
 
 #### Snapshot and Disk Management
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The following are the minimum required permissions needed by Velero to perform b
 
 To backup to the Storage Account, Velero uses the Storage Account Key which it retrieves via the Azure API if not provided. The [Storage Account Key Operator Service Role](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-account-key-operator-service-role) can be assigned to the [service principal][17] or the [AAD Pod Identity][20] to allow this.
 
-##### Snapshot and Disk Management
+#### Snapshot and Disk Management
 
 There aren't any predefined Roles in Azure that define the minimum required permissions for Velero to manage disks and snapshots.
 [Custom Roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles) can be defined using the following Azure API permissions.
@@ -164,7 +164,7 @@ These permissions are required on the Resource Group where the disks are be loca
 * Microsoft.Compute/disks/endGetAccess/action
 * Microsoft.Compute/disks/beginGetAccess/action
 
-#### Velero Snapshot Management
+##### Velero Snapshot Management
 
 These permissions are required on the Resource Group where the snapshots will be located, which may be different from where the disks are located.
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ The following are the minimum required permissions needed by Velero to perform b
 
 There are two *Azure Roles* that provide the necessary permissions for the [service principal][17] or the [AAD Pod Identity][20]:
 
-* [Storage Blob Data Contributor](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-blob-data-contributor)
 * [Storage Account Key Operator Service Role](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-account-key-operator-service-role)
 
 #### Snapshot and Disk Management

--- a/README.md
+++ b/README.md
@@ -150,12 +150,12 @@ The following are the minimum required permissions needed by Velero to perform b
 
 To backup to the Storage Account, Velero uses the Storage Account Key which it retrieves via the Azure API if not provided. The [Storage Account Key Operator Service Role](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#storage-account-key-operator-service-role) can be assigned to the [service principal][17] or the [AAD Pod Identity][20] to allow this.
 
-#### Snapshot and Disk Management
+##### Snapshot and Disk Management
 
 There aren't any predefined Roles in Azure that define the minimum required permissions for Velero to manage disks and snapshots.
 [Custom Roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles) can be defined using the following Azure API permissions.
 
-#### Velero Disk Management
+##### Velero Disk Management
 
 These permissions are required on the Resource Group where the disks are be located, which may be different from where the snapshots are located.
 

--- a/changelogs/unreleased/85-justbert
+++ b/changelogs/unreleased/85-justbert
@@ -1,0 +1,1 @@
+add section to README describing least required privileges in Azure


### PR DESCRIPTION
I'm currently in the midst of setting up the least required permissions by the plugin to perform the necessary operations and figured it would be good to upstream the information to allow others to adhere to the principle of least access.