### PR TITLE
Add changelogs for v1.1.2

### DIFF
--- a/changelogs/CHANGELOG-1.1.2.md
+++ b/changelogs/CHANGELOG-1.1.2.md
@@ -1,0 +1,3 @@
+## All changes
+
+- Fixed an issue where only the first page of results from ListBlobs was processed. Now, all pages of results are processed. (#87, @justenwalker)


### PR DESCRIPTION
The PR included in the release changelog (#87) did not include a changelog
file so this has been added manually by me.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>