### PR TITLE
Use credentials file passed through config

### DIFF
--- a/changelogs/unreleased/90-zubron
+++ b/changelogs/unreleased/90-zubron
@@ -1,0 +1,1 @@
+Add support for the new `credentialsFile` config key which enables per-BSL credentials. If set, the plugin will use this path as the credentials file for authentication rather than the credentials file path in the environment.

--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -159,8 +159,8 @@ func getSubscriptionID(config map[string]string) string {
 }
 
 func getStorageAccountKey(config map[string]string) (string, *azure.Environment, error) {
-	// load environment vars from $AZURE_CREDENTIALS_FILE, if it exists
-	if err := loadEnv(); err != nil {
+	// load environment vars from credentials file in environment or config
+	if err := loadEnvFromCredentialsFile(config); err != nil {
 		return "", nil, err
 	}
 

--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017, 2019, 2020 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -159,8 +159,12 @@ func getSubscriptionID(config map[string]string) string {
 }
 
 func getStorageAccountKey(config map[string]string) (string, *azure.Environment, error) {
-	// load environment vars from credentials file in environment or config
-	if err := loadEnvFromCredentialsFile(config); err != nil {
+	credentialsFile, err := selectCredentialsFile(config)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err := loadCredentialsIntoEnv(credentialsFile); err != nil {
 		return "", nil, err
 	}
 
@@ -246,6 +250,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		subscriptionIDConfigKey,
 		blockSizeConfigKey,
 		storageAccountKeyEnvVarConfigKey,
+		credentialsFileConfigKey,
 	); err != nil {
 		return err
 	}
@@ -405,8 +410,6 @@ func (o *ObjectStore) ListCommonPrefixes(bucket, prefix, delimiter string) ([]st
 
 	return prefixes, nil
 }
-
-
 
 func (o *ObjectStore) ListObjects(bucket, prefix string) ([]string, error) {
 	container, err := o.containerGetter.getContainer(bucket)

--- a/velero-plugin-for-microsoft-azure/volume_snapshotter.go
+++ b/velero-plugin-for-microsoft-azure/volume_snapshotter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2017, 2019, 2020 the Velero contributors.
+Copyright the Velero contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -85,8 +85,7 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 		return err
 	}
 
-	// load environment vars from $AZURE_CREDENTIALS_FILE, if it exists
-	if err := loadEnv(); err != nil {
+	if err := loadCredentialsIntoEnv(credentialsFileFromEnv()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Add a new supported key to the config (`credentialsFile`) which allows
the path to a credentials file to be passed through to the ObjectStore
plugin. If that key is set in the config, use that file as the
credentials file to load the Azure environment variables from.

Fixes vmware-tanzu/velero#3429.

Signed-off-by: Bridget McErlean <bmcerlean@vmware.com>