### PR TITLE
Fix azure environment support

### DIFF
--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -202,7 +202,7 @@ func getStorageAccountKey(config map[string]string) (string, *azure.Environment,
 	// 2. client certificate (AZURE_CERTIFICATE_PATH, AZURE_CERTIFICATE_PASSWORD)
 	// 3. username and password (AZURE_USERNAME, AZURE_PASSWORD)
 	// 4. MSI (managed service identity)
-	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	authorizer, err := auth.NewAuthorizerFromEnvironmentWithResource(env.ResourceManagerEndpoint)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "error getting authorizer from environment")
 	}

--- a/velero-plugin-for-microsoft-azure/volume_snapshotter.go
+++ b/velero-plugin-for-microsoft-azure/volume_snapshotter.go
@@ -130,7 +130,7 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 	// 2. client certificate (AZURE_CERTIFICATE_PATH, AZURE_CERTIFICATE_PASSWORD)
 	// 3. username and password (AZURE_USERNAME, AZURE_PASSWORD)
 	// 4. MSI (managed service identity)
-	authorizer, err := auth.NewAuthorizerFromEnvironment()
+	authorizer, err := auth.NewAuthorizerFromEnvironmentWithResource(env.ResourceManagerEndpoint)
 	if err != nil {
 		return errors.Wrap(err, "error getting authorizer from environment")
 	}


### PR DESCRIPTION
fixes authoriser endpoints for AzureChinaCloud support (and other Azure environments)

background:
Azure REST authoriser expects environment variable `AZURE_ENVIRONMENT` but velero is using `AZURE_CLOUD_NAME`.

fixes https://github.com/vmware-tanzu/velero/issues/3440#issuecomment-1024326143