### PR TITLE
Fix(ZRS): Volume of type ZRS must not have Zones defined (#4608)

### DIFF
--- a/velero-plugin-for-microsoft-azure/volume_snapshotter.go
+++ b/velero-plugin-for-microsoft-azure/volume_snapshotter.go
@@ -210,11 +210,12 @@ func (b *VolumeSnapshotter) CreateVolumeFromSnapshot(snapshotID, volumeType, vol
 		},
 		Tags: snapshotInfo.Tags,
 	}
-
-	// Restore the disk in the correct zone
-	regionParts := strings.Split(volumeAZ, "-")
-	if len(regionParts) >= 2 {
-		disk.Zones = &[]string{regionParts[len(regionParts)-1]}
+	// If not a volume type 'zone redundant storage' restore the disk in the correct zone
+	if (volumeType != "Premium_ZRS" && volumeType != "StandardSSD_ZRS") {
+		regionParts := strings.Split(volumeAZ, "-")
+		if len(regionParts) >= 2 {
+			disk.Zones = &[]string{regionParts[len(regionParts)-1]}
+		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), b.apiTimeout)


### PR DESCRIPTION
Issue fixed by this PR =>

During the restore of a volume of type ZRS (zone redundant storage) Veleros fail with the error :
`rpc error: code = Unknown desc = compute.DisksClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="OperationNotAllowed" Message="A disk with sku 'StandardSSD_ZRS' cannot be created in an availability zone`

Fix => https://github.com/vmware-tanzu/velero/issues/4608
No zone must be set for volume of type ZRS