### PR TITLE
use scratch as baseimage for plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN export GOARM=$( echo "${GOARM}" | cut -c2-) && \
 
 FROM busybox:1.34.1 AS busybox
 
-FROM gcr.io/distroless/base-debian10:nonroot
+FROM scratch
 COPY --from=build /go/bin/velero-plugin-for-microsoft-azure /plugins/
 COPY --from=busybox /bin/cp /bin/cp
-USER nonroot:nonroot
 ENTRYPOINT ["cp", "/plugins/velero-plugin-for-microsoft-azure", "/target/."]


### PR DESCRIPTION
See discussion in: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/pull/135