### PR TITLE
Use the environment variable when creating the custom role in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ There are two ways to specify the role: use the built-in role or create a custom
    ```
    AZURE_ROLE=Velero
    az role definition create --role-definition '{
-      "Name": "Velero",
+      "Name": "'$AZURE_ROLE'",
       "Description": "Velero related permissions to perform backups, restores and deletions",
       "Actions": [
           "Microsoft.Compute/disks/read",


### PR DESCRIPTION
Use the environment variable `AZURE_ROLE` defined just before when creating the custom role in README.

Signed-off-by:  Takuya Kawabuchi <tbuchi888@users.noreply.github.com>