### PR TITLE
Bump up Golang to 1.17.11 for Azure plugin 1.5

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.17
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.17.11
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.17.11
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.17-buster AS build
+FROM --platform=$BUILDPLATFORM golang:1.17.11-buster AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Bump up Golang to 1.17.11 for Azure plugin 1.5

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>