### PR TITLE
Fix tilt build in velero plugin for azure

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -48,4 +48,4 @@ fi
 go build \
     -o ${OUTPUT} \
     -installsuffix "static" \
-    ${PKG}/${BIN}
+    ./velero-plugin-for-microsoft-azure


### PR DESCRIPTION
Getting following error in tilt setup: Go package is not in GOROOT The change fixes the build