### PR TITLE
Update the snapshotter to support VSL credential and bump up golang

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.17
+    - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.17-buster AS build
+FROM --platform=$BUILDPLATFORM golang:1.18-buster AS build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ velero install \
     --use-volume-snapshots=false
 ```
 
-Additionally, you can specify `--use-restic` to enable restic support, and `--wait` to wait for the deployment to be ready.
+Additionally, you can specify `--use-node-agent` to enable node agent support, and `--wait` to wait for the deployment to be ready.
 
 ### Optional installation steps
 1. Specify [additional configurable parameters][7] for the `--backup-location-config` flag.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/velero-plugin-for-microsoft-azure
 
-go 1.17
+go 1.18
 
 require (
 	github.com/Azure/azure-sdk-for-go v63.4.0+incompatible

--- a/velero-plugin-for-microsoft-azure/volume_snapshotter.go
+++ b/velero-plugin-for-microsoft-azure/volume_snapshotter.go
@@ -86,11 +86,16 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 		subscriptionIDConfigKey,
 		snapsIncrementalConfigKey,
 		snapsTagsConfigKey,
+		credentialsFileConfigKey,
 	); err != nil {
 		return err
 	}
 
-	if err := loadCredentialsIntoEnv(credentialsFileFromEnv()); err != nil {
+	credentialsFile, err := selectCredentialsFile(config)
+	if err != nil {
+		return err
+	}
+	if err := loadCredentialsIntoEnv(credentialsFile); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
1. Update the snapshotter to support VSL credential
2. Bump up golang to v1.18
3. Remove restic related

Fixes https://github.com/vmware-tanzu/velero/issues/5392 Also related to https://github.com/vmware-tanzu/velero/pull/5313 and https://github.com/vmware-tanzu/velero/issues/5274

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>