### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ az storage account create \
     --sku Standard_GRS \
     --encryption-services blob \
     --https-only true \
+    --min-tls-version TLS1_2 \
     --kind BlobStorage \
     --access-tier Hot
 ```


### PR DESCRIPTION
Require TLS version 1.2 on connections to storage account.  This is the default when creating the resource from Azure Portal, but needs to be explicitly set otherwise.