### PR TITLE
Bump up the golang version to 1.18.10

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.8
+        go-version: 1.18.10
       id: go
 
     - name: Check out the code

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.8
+        go-version: 1.18.10
       id: go
 
     - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM golang:1.18.8-bullseye AS build
+FROM --platform=$BUILDPLATFORM golang:1.18.10-bullseye AS build
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
Bump up the golang version to 1.18.10

Signed-off-by: Wenkai Yin(尹文开) <yinw@vmware.com>