### PR TITLE
Revert the changes made to doc in #111

### DIFF
--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -1,6 +1,6 @@
 # Backup Storage Location
 
-The following sample Azure `BackupStorageLocation` YAML shows all of the configurable parameters. The items under `spec.config` can be provided as key-value pairs to the `velero install` command's `--backup-location-config` flag -- for example, `storageAccount=my-sa,...`.
+The following sample Azure `BackupStorageLocation` YAML shows all of the configurable parameters. The items under `spec.config` can be provided as key-value pairs to the `velero install` command's `--backup-location-config` flag -- for example, `resourceGroup=my-rg,storageAccount=my-sa,...`.
 
 ```yaml
 apiVersion: velero.io/v1
@@ -26,6 +26,11 @@ spec:
     prefix: my-prefix
 
   config:
+    # Name of the resource group containing the storage account for this backup storage location.
+    #
+    # Required.
+    resourceGroup: my-backup-resource-group
+
     # Name of the storage account for this backup storage location.
     #
     # Required.
@@ -36,26 +41,15 @@ spec:
     # Required if using a storage account access key to authenticate rather than a service principal.
     storageAccountKeyEnvVar: MY_BACKUP_STORAGE_ACCOUNT_KEY_ENV_VAR
 
+    # ID of the subscription for this backup storage location.
+    #
+    # Optional.
+    subscriptionId: my-subscription
+
     # The block size, in bytes, to use when uploading objects to Azure blob storage.
     # See https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs
     # for more information on block blobs.
     #
     # Optional (defaults to 104857600, i.e. 100MB).
     blockSizeInBytes: "104857600"
-
-    # When service principal or managed identity is used the plugin has the option to access the blob storage directly without fetching a storage access key. This feature is enabled if resourceGroup or subscriptionId isn't set.
-    # Requirements to enable direct access:
-    # - subscriptionId and resourceGroup needs to be removed from backup-location-config.
-    # - The identity accessing the storage account additionally needs the role "Storage Blob Data Contributor", else you will get this error in the velero log: `AuthorizationPermissionMismatch`.
-    # Using direct access is recommended as it will be the default in a future release.
-
-    # Name of the resource group containing the storage account for this backup storage location.
-    #
-    # Deprecated
-    resourceGroup: my-backup-resource-group
-
-    # ID of the subscription for this backup storage location.
-    #
-    # Deprecated
-    subscriptionId: my-subscription
 ```


### PR DESCRIPTION
We introduced changes in #111 to remove the logic of listing storage account access key, the Velero Azure plugin supports auth via Azure AD directly after the changes, but that isn't enough as Restic/Kopia still doesn't support auth via Azure AD at this moment, this will cause filesystem backup failure on Azure.

So we revert the doc change in this commit and Velero still needs the permission of listing storage access key to work as expected. But as we keep the code changes, users can workaround the permission issue by refer to https://github.com/vmware-tanzu/velero/issues/5984