### PR TITLE
The velero-plugin-formicrosoft-azure docs have started advising

### DIFF
--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -227,19 +227,23 @@ func newObjectStore(logger logrus.FieldLogger) *ObjectStore {
 
 // get storage account key from env var whose name is in config[storageAccountKeyEnvVarConfigKey].
 func getStorageAccountKey(config map[string]string) (string, error) {
-	credentialsFile, err := selectCredentialsFile(config)
-	if err != nil {
-		return "", err
-	}
-	if err := loadCredentialsIntoEnv(credentialsFile); err != nil {
-		return "", err
-	}
 	secretKeyEnvVar := config[storageAccountKeyEnvVarConfigKey]
 	if secretKeyEnvVar != "" {
 		return os.Getenv(secretKeyEnvVar), nil
 	}
 
 	return "", nil
+}
+
+func populateEnvVarsFromCredentialsFile(config map[string]string) error {
+	credentialsFile, err := selectCredentialsFile(config)
+	if err != nil {
+		return err
+	}
+	if err := loadCredentialsIntoEnv(credentialsFile); err != nil {
+		return err
+	}
+	return nil
 }
 
 // getServiceClient creates a client via SharedKeyCredential or DefaultAzureCredential
@@ -315,6 +319,10 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		storageAccountKeyEnvVarConfigKey,
 		credentialsFileConfigKey,
 	); err != nil {
+		return err
+	}
+
+	if err := populateEnvVarsFromCredentialsFile(config); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
adding environment variables in the credentials file. This can work, but the environment variables must be loaded early so that functions requiring those variables work correctly.

---
For testing this patch, I build the plugin container and deployed it to a govcloud AKS cluster. Details on why this has to be tested in govcloud in the bug report at https://github.com/vmware-tanzu/velero/issues/6196, specifically in the comment https://github.com/vmware-tanzu/velero/issues/6196#issuecomment-1523810703