### PR TITLE
Fix - storage account action name is "blobs" not "blob"

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ There are two ways to specify the role: use the built-in role or create a custom
           "Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action"
       ],
       "DataActions" :[
-        "Microsoft.Storage/storageAccounts/blobServices/containers/blob/delete",
-        "Microsoft.Storage/storageAccounts/blobServices/containers/blob/read",
-        "Microsoft.Storage/storageAccounts/blobServices/containers/blob/write",
-        "Microsoft.Storage/storageAccounts/blobServices/containers/blob/move/action",
-        "Microsoft.Storage/storageAccounts/blobServices/containers/blob/add/action"
+        "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/delete",
+        "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read",
+        "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write",
+        "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/move/action",
+        "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action"
       ],
       "AssignableScopes": ["/subscriptions/'$AZURE_SUBSCRIPTION_ID'"]
       }'


### PR DESCRIPTION
It seems there's a typo within the README.MD. According to our test and the ms documentation it should be "blobs" not "blob".

![grafik](https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/assets/1308503/287254d8-8bff-40d8-927c-36cf4df2f145)
