### PR TITLE
Added the capability to add custom endpoints for storage and azure active directory endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,30 +155,30 @@ If you plan to use Velero to take Azure snapshots of your persistent volume mana
 If you don't plan to take Azure disk snapshots, any method is valid.
 
 ### Specify Role
-_**Note**: This is only required for (1) by using a Velero-specific service principal and  (2) by using Azure AD Workload Identity._  
+_**Note**: This is only required for (1) by using a Velero-specific service principal and  (2) by using Azure AD Workload Identity._
 
 1. Obtain your Azure Account Subscription ID:
    ```
    AZURE_SUBSCRIPTION_ID=`az account list --query '[?isDefault].id' -o tsv`
    ```
 
-2. Specify the role  
-There are two ways to specify the role: use the built-in role or create a custom one.  
+2. Specify the role
+There are two ways to specify the role: use the built-in role or create a custom one.
    You can use the Azure built-in role `Contributor`:
    ```
    AZURE_ROLE=Contributor
    ```
    This will have subscription-wide access, so protect the credential generated with this role.
-   
-   It is always best practice to assign the minimum required permissions necessary for an application to do its work.  
-   
+
+   It is always best practice to assign the minimum required permissions necessary for an application to do its work.
+
    > Note: With useAAD flag you will need to provide extra permissions `Storage Blob Data Contributor` covered in point 3 of section: [Create service principal](#create-service-principal)
 
    Here are the minimum required permissions needed by Velero to perform backups, restores, and deletions:
    - Storage Account
       > Back Compatability and Restic
-      - Microsoft.Storage/storageAccounts/listkeys/action  
-      - Microsoft.Storage/storageAccounts/regeneratekey/action  
+      - Microsoft.Storage/storageAccounts/listkeys/action
+      - Microsoft.Storage/storageAccounts/regeneratekey/action
       > AAD Based Auth
       - Microsoft.Storage/storageAccounts/blobServices/containers/delete
       - Microsoft.Storage/storageAccounts/blobServices/containers/read
@@ -201,7 +201,7 @@ There are two ways to specify the role: use the built-in role or create a custom
       - Microsoft.Compute/snapshots/delete
       - Microsoft.Compute/disks/beginGetAccess/action
       - Microsoft.Compute/disks/endGetAccess/action
-   
+
    Use the following commands to create a custom role which has the minimum required permissions:
    ```
    AZURE_ROLE=Velero
@@ -309,7 +309,7 @@ Before proceeding, ensure that you have installed [workload identity mutating ad
 
     IDENTITY_CLIENT_ID="$(az identity show -g $AZURE_RESOURCE_GROUP -n $IDENTITY_NAME --subscription $AZURE_SUBSCRIPTION_ID --query clientId -otsv)"
     ```
-    
+
     If you'll be using Velero to backup multiple clusters with multiple blob containers, it may be desirable to create a unique identity name per cluster rather than the default `velero`.
 
 2. Assign the identity roles:
@@ -364,11 +364,11 @@ Before proceeding, ensure that you have installed [workload identity mutating ad
     ```
 
 4. Get the cluster OIDC issuer URL
-    
+
     ```bash
-    CLUSTER_RESOURCE_GROUP=<NAME_OF_CLUSTER_RESOURCE_GROUP>  
+    CLUSTER_RESOURCE_GROUP=<NAME_OF_CLUSTER_RESOURCE_GROUP>
     ```
-    **WARNING**: If you're using [AKS][25], `CLUSTER_RESOURCE_GROUP` must be set to the name of the resource group where the cluster is created, not the auto-generated resource group that is created when you provision your cluster in Azure.  
+    **WARNING**: If you're using [AKS][25], `CLUSTER_RESOURCE_GROUP` must be set to the name of the resource group where the cluster is created, not the auto-generated resource group that is created when you provision your cluster in Azure.
 
     ```bash
     CLUSTER_NAME=your_cluster_name
@@ -565,6 +565,11 @@ velero backup-location create <bsl-name> \
   --credential=bsl-credentials=azure
 ```
 
+If you would like to customize the Storage Location and or the AAD URI associated with the backup location add the following to the `--config` argument:
+```bash
+--config storageAccountURI=my-sa.blob.core.windows.net,activeDirectoryAuthorityURI='https://login.microsoftonline.us/'
+```
+
 The Backup Storage Location is ready to use when it has the phase `Available`.
 You can check this with the following command:
 
@@ -605,4 +610,4 @@ To improve security within Azure, it's good practice [to disable public traffic 
 [29]: https://learn.microsoft.com/en-us/azure/aks/use-oidc-issuer#create-an-aks-cluster-with-oidc-issuer
 [101]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/workflows/Main%20CI/badge.svg
 [102]: https://github.com/vmware-tanzu/velero-plugin-for-microsoft-azure/actions?query=workflow%3A"Main+CI"
-[103]: https://github.com/vmware-tanzu/velero/issues/new/choose 
+[103]: https://github.com/vmware-tanzu/velero/issues/new/choose

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -46,18 +46,25 @@ spec:
     # Optional.
     subscriptionId: my-subscription
 
-    # URI of the blob endpoint of the storage account. 
-    # 
-    # Optional. This will ensure that velero uses the provided URI to communicate to the Storage Account, 
+    # URI of the blob endpoint of the storage account.
+    #
+    # Optional. This will ensure that velero uses the provided URI to communicate to the Storage Account,
     # and it will not try to fetch the Endpoint by making an ARM call.
     # If this field is provided then resourceGroup, subscriptionId can be left empty
     storageAccountURI: my-sa.blob.core.windows.net
 
-    # Boolean parameter to decide whether to use AAD for authenticating with the storage account. 
+    # Boolean parameter to decide whether to use AAD for authenticating with the storage account.
     # If false/ not provided, plugin will fallback to using ListKeys
     #
     # Optional. Recommended.
     useAAD: "true"
+
+    # URI of the AAD endpoint of the storage account.
+    #
+    # Note that useAAD: should be set to "true" in order to use the provided AAD URI and http(s):// scheme is required to authenticate
+    #
+    # Optional. This will ensure that velero uses the provided AAD URI to authenticate to the Storage Account.
+    activeDirectoryAuthorityURI: https://login.microsoftonline.us/
 
     # The block size, in bytes, to use when uploading objects to Azure blob storage.
     # See https://docs.microsoft.com/en-us/rest/api/storageservices/understanding-block-blobs--append-blobs--and-page-blobs#about-block-blobs

--- a/velero-plugin-for-microsoft-azure/object_store.go
+++ b/velero-plugin-for-microsoft-azure/object_store.go
@@ -46,11 +46,12 @@ import (
 )
 
 const (
-	storageAccountConfigKey          = "storageAccount"
-	storageAccountKeyEnvVarConfigKey = "storageAccountKeyEnvVar"
-	blockSizeConfigKey               = "blockSizeInBytes"
-	storageAccountURIConfigKey       = "storageAccountURI"
-	useAADConfigKey                  = "useAAD"
+	storageAccountConfigKey              = "storageAccount"
+	storageAccountKeyEnvVarConfigKey     = "storageAccountKeyEnvVar"
+	blockSizeConfigKey                   = "blockSizeInBytes"
+	storageAccountURIConfigKey           = "storageAccountURI"
+	useAADConfigKey                      = "useAAD"
+	activeDirectoryAuthorityURIConfigKey = "activeDirectoryAuthorityURI"
 
 	// blocks must be less than/equal to 100MB in size
 	// ref. https://docs.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters
@@ -334,6 +335,7 @@ func (o *ObjectStore) Init(config map[string]string) error {
 		blockSizeConfigKey,
 		storageAccountURIConfigKey,
 		useAADConfigKey,
+		activeDirectoryAuthorityURIConfigKey,
 		storageAccountKeyEnvVarConfigKey,
 		credentialsFileConfigKey,
 	); err != nil {
@@ -354,6 +356,11 @@ func (o *ObjectStore) Init(config map[string]string) error {
 	cloudConfig, err := cloudFromName(os.Getenv(cloudNameEnvVar))
 	if err != nil {
 		return errors.Wrap(err, "unable to parse azure cloud name environment variable")
+	}
+
+	// Update active directory authority host if it is set in the configuration
+	if config[activeDirectoryAuthorityURIConfigKey] != "" && config[useAADConfigKey] == "true" {
+		cloudConfig.ActiveDirectoryAuthorityHost = config[activeDirectoryAuthorityURIConfigKey]
 	}
 
 	o.log.Debugf("Getting storage key")

--- a/velero-plugin-for-microsoft-azure/object_store_integration_test.go
+++ b/velero-plugin-for-microsoft-azure/object_store_integration_test.go
@@ -86,6 +86,18 @@ func TestE2E(t *testing.T) {
 			},
 		},
 		{
+			scenario: "AAD and SA URI is provided - getProperties is not called, custom AAD is used",
+			config: map[string]string{
+				storageAccountConfigKey:          		"velerotest",
+				storageAccountKeyEnvVarConfigKey: 		"AZ_STORAGE_KEY",
+				resourceGroupConfigKey:           		"saRgName",
+				subscriptionIDConfigKey:          		"81d18ba6-71e1-4858-a4a4-4c527ccdd4d6",
+				storageAccountURIConfigKey:           	"https://velerotest.blob.core.windows.net/",
+				useAADConfigKey:                  	  	"true",
+				activeDirectoryAuthorityURIConfigKey: 	"https://core.windows.net"
+			},
+		},
+		{
 			scenario: "GetProperties + ListKeys - AAD enabled",
 			config: map[string]string{
 				storageAccountConfigKey:          "velerotest",

--- a/velero-plugin-for-microsoft-azure/volume_snapshotter.go
+++ b/velero-plugin-for-microsoft-azure/volume_snapshotter.go
@@ -46,9 +46,10 @@ import (
 const (
 	resourceGroupEnvVar = "AZURE_RESOURCE_GROUP"
 
-	apiTimeoutConfigKey       = "apiTimeout"
-	snapsIncrementalConfigKey = "incremental"
-	snapsTagsConfigKey        = "tags"
+	apiTimeoutConfigKey                       = "apiTimeout"
+	snapsIncrementalConfigKey                 = "incremental"
+	snapsTagsConfigKey                        = "tags"
+	snapsActiveDirectoryAuthorityURIConfigKey = "activeDirectoryAuthorityURI"
 
 	snapshotsResource = "snapshots"
 	disksResource     = "disks"
@@ -125,6 +126,11 @@ func (b *VolumeSnapshotter) Init(config map[string]string) error {
 	cloudConfig, err := cloudFromName(os.Getenv(cloudNameEnvVar))
 	if err != nil {
 		return errors.Wrap(err, "unable to parse azure cloud name environment variable")
+	}
+
+	// Update active directory authority host if it is set in the configuration
+	if config[snapsActiveDirectoryAuthorityURIConfigKey] != "" {
+		cloudConfig.ActiveDirectoryAuthorityHost = config[snapsActiveDirectoryAuthorityURIConfigKey]
 	}
 
 	// if config["apiTimeout"] is empty, default to 2m; otherwise, parse it

--- a/volumesnapshotlocation.md
+++ b/volumesnapshotlocation.md
@@ -32,6 +32,13 @@ spec:
     # Optional.
     subscriptionId: alt-subscription
 
+    # URI of the AAD endpoint of the volume snapshots account.
+    #
+    # Note that the fully qualified AAD URI with http(s):// scheme is required to authenticate
+    #
+    # Optional. This will ensure that velero uses the provided AAD URI to authenticate to the volume snapshots account.
+    activeDirectoryAuthorityURI: https://login.microsoftonline.us/
+
     # Azure offers the option to take full or incremental snapshots of managed disks.
     # - Set this parameter to true, to take incremental snapshots.
     # - If the parameter is omitted or set to false, full snapshots are taken (default).


### PR DESCRIPTION
Why:
This feature pull request allows the user to define the storage endpoints and azure active directory endpoints. This is needed for azure gov / other regions where the directory and storage endpoints aren't public and do not fall under the default provided clouds. 

Additions:
- Go Int Tests to verify that the output is as expected
- Added new backupstoragelocation config values
  - activeDirectoryAuthorityURI
- Added new volumesnapshotlocation config values
  - activeDirectoryAuthorityURI