### PR TITLE
Fix JSON syntax issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ There are two ways to specify the role: use the built-in role or create a custom
           "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
           "Microsoft.Storage/storageAccounts/blobServices/containers/read",
           "Microsoft.Storage/storageAccounts/blobServices/containers/write",
-          "Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action",
+          "Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action"
       ],
       "DataActions" :[
         "Microsoft.Storage/storageAccounts/blobServices/containers/blob/delete",
@@ -233,7 +233,7 @@ There are two ways to specify the role: use the built-in role or create a custom
         "Microsoft.Storage/storageAccounts/blobServices/containers/blob/write",
         "Microsoft.Storage/storageAccounts/blobServices/containers/blob/move/action",
         "Microsoft.Storage/storageAccounts/blobServices/containers/blob/add/action"
-      ]
+      ],
       "AssignableScopes": ["/subscriptions/'$AZURE_SUBSCRIPTION_ID'"]
       }'
    ```


### PR DESCRIPTION
Fix json syntax issues for Azure az role example

It looks DataActions is not needed or supported in more current. Not sure if you want to remove that. Here is what worked for me.

```
#!/bin/bash
set -eu
AZURE_ROLE=Velero
AZURE_SUBSCRIPTION_ID=<my subscription id>
az role definition create --role-definition '{
   "Name": "'$AZURE_ROLE'",
   "Description": "Velero related permissions to perform backups, restores and deletions for AKS",
   "Actions": [
       "Microsoft.Compute/disks/read",
       "Microsoft.Compute/disks/write",
       "Microsoft.Compute/disks/endGetAccess/action",
       "Microsoft.Compute/disks/beginGetAccess/action",
       "Microsoft.Compute/snapshots/read",
       "Microsoft.Compute/snapshots/write",
       "Microsoft.Compute/snapshots/delete",
       "Microsoft.Storage/storageAccounts/listkeys/action",
       "Microsoft.Storage/storageAccounts/regeneratekey/action",
       "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
       "Microsoft.Storage/storageAccounts/blobServices/containers/read",
       "Microsoft.Storage/storageAccounts/blobServices/containers/write",
       "Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey/action"
   ],
   "DataActions" :[
   ],
   "AssignableScopes": ["/subscriptions/'$AZURE_SUBSCRIPTION_ID'"]
   }'
```