### PR TITLE
Fix volume snapshotter usage of AAD URI

### DIFF
--- a/changelogs/unreleased/256-dylanbossie-rise8
+++ b/changelogs/unreleased/256-dylanbossie-rise8
@@ -1,0 +1,1 @@
+Update volume_snapshotter to correctly use AAD URI which fixes behavior for Azure Workload Identities

--- a/velero-plugin-for-microsoft-azure/volume_snapshotter.go
+++ b/velero-plugin-for-microsoft-azure/volume_snapshotter.go
@@ -87,6 +87,7 @@ func newVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
 	if err := veleroplugin.ValidateVolumeSnapshotterConfigKeys(config,
+		vslConfigKeyActiveDirectoryAuthorityURI,
 		vslConfigKeyResourceGroup,
 		vslConfigKeyAPITimeout,
 		vslConfigKeySubscriptionID,


### PR DESCRIPTION
Currently AAD URI will throw an error with volume snapshotter, and in practice will cause volume snapshots to be attempted using DefaultAzureCredential when used with Azure, which causes failures in certain contexts. This should resolve that issue.