### PR TITLE
Issue 3159: Added support for AzureStackHub and Azure private cloud identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,31 @@ _Note: this option is **not valid** if you are planning to take Azure snapshots 
 
     > Available values for `AZURE_CLOUD_NAME`: `AzurePublicCloud`, `AzureUSGovernmentCloud`, `AzureChinaCloud`
 
+### Using Azure Custom or Stack clouds
+
+When using custom Azure clouds, there are two methods to configure velero. For potential APIVersion conflicts between the internal azure go SDK versions and the versions of AzureStack or custom clouds, both `BackupStorageLocation` and `VolumeSnapshotLocation` config support an `apiVersion` parameter to pin requests to a specific APIVersion for service api calls.
+
+#### Option 1: Use Azure ResourceManager endpoint discovery
+
+  ```bash
+  cat << EOF > ./credentials-velero
+  AZURE_CLOUD_NAME=AzureCustomCloud
+  AZURE_RESOURCE_MANAGER_ENDPOINT=<Azure resource manager endpoint. For example, https://management.usgovcloudapi.net>
+  EOF
+  ```
+
+#### Option 2: Use Azure cloud configuration
+
+1. Ensure that a valid [cloud provider configuration](https://cloud-provider-azure.sigs.k8s.io/install/configs/) has been created. If using AKS, this can be mounted from the host path `/etc/kubernetes/azurestackcloud.json`
+2. Ensure that the environment variable `AZURE_ENVIRONMENT_FILEPATH` has been set to the location of the file from step 1
+3. Set the configuration (cloud name **must** be `AzureStackCloud`)
+
+  ```bash
+  cat << EOF > ./credentials-velero
+  AZURE_CLOUD_NAME=AzureStackCloud
+  EOF
+  ```
+
 ## Install and start Velero
 
 [Download][6] Velero

--- a/backupstoragelocation.md
+++ b/backupstoragelocation.md
@@ -72,4 +72,9 @@ spec:
     #
     # Optional (defaults to 1048576, i.e. 1MB, maximum 104857600, i.e. 100MB).
     blockSizeInBytes: "1048576"
+
+    # APIVersion of the Azure storage account blob service.
+
+    # Optional. This can be used in environments where the supported API versions do not match the default azure client version.
+    apiVersion: ""
 ```

--- a/volumesnapshotlocation.md
+++ b/volumesnapshotlocation.md
@@ -50,4 +50,9 @@ spec:
     #
     # Optional.
     tags: key1=value1,key2=value2
+
+    # APIVersion of the Azure managed disk service.
+
+    # Optional. This can be used in environments where the supported API versions do not match the default azure client version.
+    apiVersion: ""
 ```


### PR DESCRIPTION
This feature updates the documentation and recompiles the plugin against [PR8738](https://github.com/vmware-tanzu/velero/pull/8738) to include support for AzureStackHub and Private Azure cloud environments.

Additionally added an optional configuration option `apiVersion` to help with API version drift between these environments and the azure golang sdk default versions.