### PR TITLE
Fix Auto Request Review workflow: bump action version and pass token

### DIFF
--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -11,10 +11,12 @@ permissions:
 
 jobs:
   auto-request-review:
+    if: github.repository == 'velero-io/velero-plugin-for-microsoft-azure'
     name: Auto Request Review
     runs-on: ubuntu-latest
     steps:
       - name: Request a PR review based on files types/paths, and/or groups the author belongs to
-        uses: necojackarc/auto-request-review@v0.7.0
+        uses: necojackarc/auto-request-review@v0.13.0
         with:
           config: .github/auto-assignees.yml
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `necojackarc/auto-request-review@v0.7.0` fails on every PR with `Error: Parameter token or opts.auth is required` (see failing "Auto Request Review" check on #317, #316, #313, etc.)
- Newer versions of the action require the GitHub token to be passed explicitly instead of picking it up implicitly
- `velero-io/velero` already fixed this by bumping to `v0.13.0` and passing `token: ${{ secrets.GITHUB_TOKEN }}` — this PR mirrors that fix here, plus adds the same `if: github.repository == ...` guard

## Test plan
- [ ] Confirm the "Auto Request Review" check passes on this PR once merged and exercised by a subsequent PR

> [!Note]
> Responses generated with Claude