### PR TITLE
Add CODEOWNERS for automatic review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# maintainers are the overall code owners
+* @velero-io/Maintainer


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` (`* @velero-io/Maintainer`) so review requests happen automatically via GitHub's native code-owners feature — no third-party Action, no token, nothing to version-pin
- Complements #318, which fixes the currently-broken `auto_request_review.yml` (missing token) — this CODEOWNERS file provides the same coverage natively, independent of that Action's health. We might consider removing that action entirely

See discussion: velero-io/velero#10018

## Test plan
- [ ] Confirm review gets auto-requested from @velero-io/Maintainer on this PR

> [!Note]
> Responses generated with Claude