### PR TITLE
[release-1.14] Fix volume snapshotter usage of AAD URI (backport of #256)

### DIFF
--- a/changelogs/unreleased/256-dylanbossie-rise8
+++ b/changelogs/unreleased/256-dylanbossie-rise8
@@ -1,0 +1,1 @@
+Update volume_snapshotter to correctly use AAD URI which fixes behavior for Azure Workload Identities

--- a/velero-plugin-for-microsoft-azure/volume_snapshotter.go
+++ b/velero-plugin-for-microsoft-azure/volume_snapshotter.go
@@ -87,6 +87,7 @@ func newVolumeSnapshotter(logger logrus.FieldLogger) *VolumeSnapshotter {
 
 func (b *VolumeSnapshotter) Init(config map[string]string) error {
 	if err := veleroplugin.ValidateVolumeSnapshotterConfigKeys(config,
+		vslConfigKeyActiveDirectoryAuthorityURI,
 		vslConfigKeyResourceGroup,
 		vslConfigKeyAPITimeout,
 		vslConfigKeySubscriptionID,


### PR DESCRIPTION
## Summary
Backport of #256 ("Fix volume snapshotter usage of AAD URI") to `release-1.14`.

`vslConfigKeyActiveDirectoryAuthorityURI` was defined but never added to `ValidateVolumeSnapshotterConfigKeys`'s allow-list, so setting `activeDirectoryAuthorityURI` in the VSL config threw an "invalid option" error and silently fell back to `DefaultAzureCredential` — breaking Azure Workload Identity auth.

Clean cherry-pick of the merge commit (`1ebe6de4badae61a6bc2fe28d34895b1a63f731f`) from `main` — no code changes beyond what was already reviewed/approved there.

> [!Note]
> Responses generated with Claude